### PR TITLE
Rename annoation target 'class' to 'object'

### DIFF
--- a/src/dann/zcl_aap_dann_deprecated.clas.abap
+++ b/src/dann/zcl_aap_dann_deprecated.clas.abap
@@ -28,7 +28,7 @@ CLASS zcl_aap_dann_deprecated IMPLEMENTATION.
 
   METHOD get_targets_internal.
     rt_targets = VALUE #(
-      ( zcl_aap_annotation_target=>go_class )
+      ( zcl_aap_annotation_target=>go_object )
       ( zcl_aap_annotation_target=>go_method )
     ).
   ENDMETHOD.

--- a/src/proc/zcl_aap_proc_object.clas.abap
+++ b/src/proc/zcl_aap_proc_object.clas.abap
@@ -355,6 +355,6 @@ CLASS zcl_aap_proc_object IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD get_target.
-    ro_target = zcl_aap_annotation_target=>go_class.
+    ro_target = zcl_aap_annotation_target=>go_object.
   ENDMETHOD.
 ENDCLASS.

--- a/src/zcl_aap_annotation_target.clas.abap
+++ b/src/zcl_aap_annotation_target.clas.abap
@@ -1,3 +1,4 @@
+"! Targets enumeration with targets for annotations or annotation processors
 CLASS zcl_aap_annotation_target DEFINITION
   PUBLIC
   FINAL
@@ -7,9 +8,13 @@ CLASS zcl_aap_annotation_target DEFINITION
     CLASS-METHODS:
       class_constructor.
     CLASS-DATA:
-      go_class     TYPE REF TO zcl_aap_annotation_target READ-ONLY,
+      "! Class / interface
+      go_object    TYPE REF TO zcl_aap_annotation_target READ-ONLY,
+      "! Method
       go_method    TYPE REF TO zcl_aap_annotation_target READ-ONLY,
+      "! Method parameter
       go_parameter TYPE REF TO zcl_aap_annotation_target READ-ONLY,
+      "! Attribute
       go_attribute TYPE REF TO zcl_aap_annotation_target READ-ONLY.
     DATA:
       mv_key TYPE char01 READ-ONLY.
@@ -23,7 +28,7 @@ ENDCLASS.
 
 CLASS zcl_aap_annotation_target IMPLEMENTATION.
   METHOD class_constructor.
-    init: go_class     'C',
+    init: go_object    'O',
           go_method    'M',
           go_parameter 'P',
           go_attribute 'A'.


### PR DESCRIPTION
This is analog to the type descriptor api, where objectdescr is a base class for both intfdescr and classdescr.